### PR TITLE
crypto.pbkdf2 with digest param

### DIFF
--- a/lib/hashsalt.js
+++ b/lib/hashsalt.js
@@ -21,7 +21,7 @@ var password = function(password) {
 			}
 
 			var calcHash = function() {
-				crypto.pbkdf2(password, salt, iterations, 64, function(err, key) {
+				crypto.pbkdf2(password, salt, iterations, 64, 'sha512', function(err, key) {
 					if(err)
 						return callback(err);
 					var res = 'pbkdf2$' + iterations + 


### PR DESCRIPTION
Hi @florianheinemann,

i recently updated to node.js v6.0.0 and i see `(node:21314) DeprecationWarning: crypto.pbkdf2 without specifying a digest is deprecated. Please specify a digest`.

By specifying a digest parameter this log goes away.
