### PR TITLE
Update hashsalt.js

### DIFF
--- a/lib/hashsalt.js
+++ b/lib/hashsalt.js
@@ -21,7 +21,7 @@ var password = function(password) {
 			}
 
 			var calcHash = function() {
-				crypto.pbkdf2(password, salt, iterations, 64, function(err, key) {
+				crypto.pbkdf2(password, salt, iterations, 64, 'sha1', function(err, key) {
 					if(err)
 						return callback(err);
 					var res = 'pbkdf2$' + iterations + 


### PR DESCRIPTION
Updated to bring into compliance with deprecation warning:
"(node:4975) DeprecationWarning: crypto.pbkdf2 without specifying a digest is deprecated. Please specify a digest."

https://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback

Digest specified as 'sha1' which was the default before, this ensures existing hashes continue to be validated without issues.
